### PR TITLE
Add Profile Attribute APIs for both Android & iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,16 @@ The second step is setting your sfmc contact key which is a unique client id in 
 await SfmcPlugin().setContactKey('<Uniquely Identifying Key>');
 ```
 
+### Attributes
+
+You can use attributes to segment your audience and personalize your messages. Before you can use attributes, create them in your MobilePush account. Attributes may only be set or cleared by the SDK. See the [Reserved Words](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/sdk-implementation/device-contact-registration.html#reserved-words) section for a list of attribute keys that can’t be modified by the SDK or your application.
+
+```dart
+await SfmcPlugin().setProfileAttribute("key", "value");
+
+await SfmcPlugin().clearProfileAttribute("key");
+```
+
 ## Contributions
 
 🍺 Pull requests are welcome!

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.0
+
+* Add `setProfileAttribute` and `clearProfileAttribute` methods for both Android and iOS Platforms
+
 ## 3.0.0
 
 * Migrate iOS MarketingCloudSDK to 8.0.8 and SFMCSdk 1.0.6 - iOS Only

--- a/src/README.md
+++ b/src/README.md
@@ -112,6 +112,17 @@ The second step is setting your sfmc contact key which is a unique client id in 
 await SfmcPlugin().setContactKey('<Uniquely Identifying Key>');
 ```
 
+### Attributes
+
+You can use attributes to segment your audience and personalize your messages. Before you can use attributes, create them in your MobilePush account. Attributes may only be set or cleared by the SDK. See the [Reserved Words](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/sdk-implementation/device-contact-registration.html#reserved-words) section for a list of attribute keys that can’t be modified by the SDK or your application.
+
+```dart
+await SfmcPlugin().setProfileAttribute("key", "value");
+
+await SfmcPlugin().clearProfileAttribute("key");
+```
+
+
 ## Contributions
 
 🍺 Pull requests are welcome!

--- a/src/android/src/main/kotlin/com/example/sfmc_plugin/SfmcPlugin.kt
+++ b/src/android/src/main/kotlin/com/example/sfmc_plugin/SfmcPlugin.kt
@@ -106,6 +106,7 @@ class SfmcPlugin : FlutterPlugin, MethodCallHandler {
                 }
             }
             "setProfileAttribute" -> {
+                var isSuccessful: Boolean
                 val attributeKey: String? = call.argument<String?>("key")
                 val attributeValue: String? = call.argument<String?>("value")
                 if (attributeKey == null || attributeKey == "") {
@@ -116,33 +117,32 @@ class SfmcPlugin : FlutterPlugin, MethodCallHandler {
                     result.error("Attribute Value is not valid", "Attribute Value is not valid", "Attribute Value is not valid");
                     return
                 }
-                try {
+                isSuccessful = try {
                     SFMCSdk.requestSdk { sdk ->
-                        sdk.identity.run {
-                            setProfileAttribute(attributeKey, attributeValue)
-                            result.success(true)
-                        }
+                        sdk.identity.setProfileAttribute(attributeKey, attributeValue)
                     }
+                    true
                 } catch (e: RuntimeException) {
-                    result.error(e.toString(), e.toString(), e.toString())
+                    false
                 }
+                result.success(isSuccessful)
             }
             "clearProfileAttribute" -> {
+                var isSuccessful: Boolean
                 val attributeKey: String? = call.argument<String?>("key")
                 if (attributeKey == null || attributeKey == "") {
                     result.error("Attribute Key is not valid", "Attribute Key is not valid", "Attribute Key is not valid");
                     return
                 }
-                try {
+                isSuccessful = try {
                     SFMCSdk.requestSdk { sdk ->
-                        sdk.identity.run {
-                            clearProfileAttribute(attributeKey)
-                            result.success(true)
-                        }
+                        sdk.identity.clearProfileAttribute(attributeKey)
                     }
+                    true
                 } catch (e: RuntimeException) {
-                    result.error(e.toString(), e.toString(), e.toString())
+                    false
                 }
+                result.success(isSuccessful)
             }
             "setPushEnabled" -> {
                 val enablePush: Boolean = call.argument<Boolean>("isEnabled") as Boolean

--- a/src/android/src/main/kotlin/com/example/sfmc_plugin/SfmcPlugin.kt
+++ b/src/android/src/main/kotlin/com/example/sfmc_plugin/SfmcPlugin.kt
@@ -105,6 +105,45 @@ class SfmcPlugin : FlutterPlugin, MethodCallHandler {
                     result.error(e.toString(), e.toString(), e.toString())
                 }
             }
+            "setProfileAttribute" -> {
+                val attributeKey: String? = call.argument<String?>("key")
+                val attributeValue: String? = call.argument<String?>("value")
+                if (attributeKey == null || attributeKey == "") {
+                    result.error("Attribute Key is not valid", "Attribute Key is not valid", "Attribute Key is not valid");
+                    return
+                }
+                if (attributeValue == null || attributeValue == "") {
+                    result.error("Attribute Value is not valid", "Attribute Value is not valid", "Attribute Value is not valid");
+                    return
+                }
+                try {
+                    SFMCSdk.requestSdk { sdk ->
+                        sdk.identity.run {
+                            setProfileAttribute(attributeKey, attributeValue)
+                            result.success(true)
+                        }
+                    }
+                } catch (e: RuntimeException) {
+                    result.error(e.toString(), e.toString(), e.toString())
+                }
+            }
+            "clearProfileAttribute" -> {
+                val attributeKey: String? = call.argument<String?>("key")
+                if (attributeKey == null || attributeKey == "") {
+                    result.error("Attribute Key is not valid", "Attribute Key is not valid", "Attribute Key is not valid");
+                    return
+                }
+                try {
+                    SFMCSdk.requestSdk { sdk ->
+                        sdk.identity.run {
+                            clearProfileAttribute(attributeKey)
+                            result.success(true)
+                        }
+                    }
+                } catch (e: RuntimeException) {
+                    result.error(e.toString(), e.toString(), e.toString())
+                }
+            }
             "setPushEnabled" -> {
                 val enablePush: Boolean = call.argument<Boolean>("isEnabled") as Boolean
                 if (enablePush) {

--- a/src/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/src/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>9.0</string>
+  <string>11.0</string>
 </dict>
 </plist>

--- a/src/example/ios/Podfile.lock
+++ b/src/example/ios/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
   - MarketingCloud-SFMCSdk (1.0.6)
   - MarketingCloudSDK (8.0.8):
     - MarketingCloud-SFMCSdk (~> 1.0.6)
-  - sfmc_plugin (3.0.0):
+  - sfmc_plugin (3.2.0):
     - Flutter
     - MarketingCloud-SFMCSdk (= 1.0.6)
     - MarketingCloudSDK (= 8.0.8)
@@ -37,7 +37,7 @@ SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   MarketingCloud-SFMCSdk: ae74604b0294527865fd4daa640698e3b1c13e1b
   MarketingCloudSDK: 4d18e897dab4aeb676ffa03fbd814ee47d41c9d3
-  sfmc_plugin: 22244f8a52647b1f72db28384a8dcaa59e185474
+  sfmc_plugin: 45ecc68ac71a26819243df969fb163d442138c2c
   shared_preferences_ios: 548a61f8053b9b8a49ac19c1ffbc8b92c50d68ad
   uni_links: d97da20c7701486ba192624d99bffaaffcfc298a
 

--- a/src/ios/Classes/SwiftSfmcPlugin.swift
+++ b/src/ios/Classes/SwiftSfmcPlugin.swift
@@ -140,7 +140,7 @@ public class SwiftSfmcPlugin: NSObject, FlutterPlugin {
     }
 
     func clearProfileAttribute(key: String) -> Bool {
-        SFMCSdk.identity.setProfileAttribute(key, "")
+        SFMCSdk.identity.clearProfileAttribute(key: key)
         return true
     }
     

--- a/src/ios/Classes/SwiftSfmcPlugin.swift
+++ b/src/ios/Classes/SwiftSfmcPlugin.swift
@@ -135,11 +135,13 @@ public class SwiftSfmcPlugin: NSObject, FlutterPlugin {
     }
 
     func setProfileAttribute(key: String, value: String) -> Bool {
-        return SFMCSdk.identity.setProfileAttribute(key, value)
+        SFMCSdk.identity.setProfileAttribute(key, value)
+        return true
     }
 
     func clearProfileAttribute(key: String) -> Bool {
-        return SFMCSdk.identity.setProfileAttributes([[key: ""]])
+        SFMCSdk.identity.setProfileAttribute(key, "")
+        return true
     }
     
     func setPushEnabled(isEnabled: Bool) -> Bool {

--- a/src/ios/Classes/SwiftSfmcPlugin.swift
+++ b/src/ios/Classes/SwiftSfmcPlugin.swift
@@ -139,6 +139,31 @@ public class SwiftSfmcPlugin: NSObject, FlutterPlugin {
                 return
             }
             result(removeTag(tag:tag!))
+        }else if call.method == "setProfileAttribute" {
+            
+            guard let args = call.arguments as? [String : Any] else {return}
+            let key = args["key"] as! String?
+            let value = args["value"] as! String?
+
+            if key == nil {
+                result(false)
+                return
+            }
+            if value == nil {
+                result(false)
+                return
+            }
+            result(setProfileAttribute(key: key!, value: value!))
+        }else if call.method == "clearProfileAttribute" {
+            
+            guard let args = call.arguments as? [String : Any] else {return}
+            let key = args["key"] as! String?
+
+            if key == nil {
+                result(false)
+                return
+            }
+            result(clearProfileAttribute(key: key!))
         } else if call.method == "setPushEnabled" {
             guard let args = call.arguments as? [String : Any] else {return}
             let isEnabled = args["isEnabled"] as! Bool?
@@ -166,6 +191,14 @@ public class SwiftSfmcPlugin: NSObject, FlutterPlugin {
     
     func removeTag(tag: String) -> Bool {
         return SFMCSdk.mp.removeTag(tag)
+    }
+
+    func setProfileAttribute(key: String, value: String) -> Bool {
+        return SFMCSdk.identity.setProfileAttribute(key, value)
+    }
+
+    func clearProfileAttribute(key: String) -> Bool {
+        return SFMCSdk.identity.setProfileAttributes([[key: ""]])
     }
     
     func setPushEnabled(isEnabled: Bool) -> Bool {

--- a/src/ios/sfmc_plugin.podspec
+++ b/src/ios/sfmc_plugin.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'sfmc_plugin'
-  s.version          = '3.1.0'
+  s.version          = '3.2.0'
   s.summary          = 'SFMC Flutter plugin project.'
   s.description      = <<-DESC
   MarketingCloudSDK - MobilePush SDK for Flutter.

--- a/src/ios/sfmc_plugin.podspec
+++ b/src/ios/sfmc_plugin.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'sfmc_plugin'
-  s.version          = '3.0.0'
+  s.version          = '3.1.0'
   s.summary          = 'SFMC Flutter plugin project.'
   s.description      = <<-DESC
   MarketingCloudSDK - MobilePush SDK for Flutter.

--- a/src/lib/sfmc_plugin.dart
+++ b/src/lib/sfmc_plugin.dart
@@ -42,6 +42,15 @@ class SfmcPlugin {
   /// To Get Tags
   Future<List<String>> getTags() => SfmcPluginPlatform.instance.getTags();
 
+  /// Set Profile Attribute
+  /// @param key - Key of the attribute
+  /// @param value - Value of the attribute
+  Future<bool?> setProfileAttribute(String key, String value) => SfmcPluginPlatform.instance.setProfileAttribute(key, value);
+
+  /// Clear Profile Attribute
+  /// @param key - Key of the attribute
+  Future<bool?> clearProfileAttribute(String key) => SfmcPluginPlatform.instance.clearProfileAttribute(key);
+
   /// To Enable/Disable Push Notification
   Future<bool?> setPushEnabled(bool? enabled) async =>
       SfmcPluginPlatform.instance.setPushEnabled(enabled);

--- a/src/lib/sfmc_plugin_method_channel.dart
+++ b/src/lib/sfmc_plugin_method_channel.dart
@@ -75,6 +75,23 @@ class MethodChannelSfmcPlugin extends SfmcPluginPlatform {
   }
 
   @override
+  Future<bool?> setProfileAttribute(String key, String value) async {
+    final bool? result = await methodChannel.invokeMethod('setProfileAttribute', {
+      "key": key,
+      "value": value,
+    });
+    return result;
+  }
+  
+  @override
+  Future<bool?> clearProfileAttribute(String key) async {
+    final bool? result = await methodChannel.invokeMethod('clearProfileAttribute', {
+      "key": key,
+    });
+    return result;
+  }
+
+  @override
   Future<bool?> setPushEnabled(bool? enabled) async {
     final bool? result = await methodChannel.invokeMethod('setPushEnabled', {
       "isEnabled": enabled ?? true,

--- a/src/lib/sfmc_plugin_platform_interface.dart
+++ b/src/lib/sfmc_plugin_platform_interface.dart
@@ -51,6 +51,15 @@ abstract class SfmcPluginPlatform extends PlatformInterface {
   /// To Remove Tags
   Future<bool?> removeTag(String? tag) => _instance.removeTag(tag);
 
+  /// Set Profile Attribute
+  /// @param key - Key of the attribute
+  /// @param value - Value of the attribute
+  Future<bool?> setProfileAttribute(String key, String value) => _instance.setProfileAttribute(key, value);
+
+  /// Clear Profile Attribute
+  /// @param key - Key of the attribute
+  Future<bool?> clearProfileAttribute(String key) => _instance.clearProfileAttribute(key);
+
   /// To Get Tags
   Future<List<String>> getTags() => _instance.getTags();
 

--- a/src/pubspec.yaml
+++ b/src/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sfmc_plugin
 description: Salesforce Marketing Cloud (SFMC) - MobilePush SDK for Flutter. Implement the MobilePush SDK for your iOS and Android applications in Flutter.
-version: 3.0.0
+version: 3.1.0
 homepage: https://github.com/sefidgaran/salesforce-marketing-cloud
 
 environment:

--- a/src/pubspec.yaml
+++ b/src/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sfmc_plugin
 description: Salesforce Marketing Cloud (SFMC) - MobilePush SDK for Flutter. Implement the MobilePush SDK for your iOS and Android applications in Flutter.
-version: 3.1.0
+version: 3.2.0
 homepage: https://github.com/sefidgaran/salesforce-marketing-cloud
 
 environment:


### PR DESCRIPTION
## Set Profile  Attributes

You can use attributes to segment your audience and personalize your messages. Before you can use attributes, create them in your MobilePush account. Attributes may only be set or cleared by the SDK. See the [Reserved Words](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/sdk-implementation/device-contact-registration.html#reserved-words) section for a list of attribute keys that can’t be modified by the SDK or your application.

### New APIs
```dart
await SfmcPlugin().setProfileAttribute("key", "value");

await SfmcPlugin().clearProfileAttribute("key");
```

- Test passed on all platforms